### PR TITLE
Add static resources by default

### DIFF
--- a/src/leiningen/new/compojure.clj
+++ b/src/leiningen/new/compojure.clj
@@ -19,4 +19,5 @@
              ["project.clj" (render project-file)]
              ["README.md"   (render "README.md")]
              ["src/{{sanitized}}/handler.clj"       (render "handler.clj")]
-             ["test/{{sanitized}}/test/handler.clj" (render "handler_test.clj")])))
+             ["test/{{sanitized}}/test/handler.clj" (render "handler_test.clj")]
+             "resources/public")))

--- a/src/leiningen/new/compojure/handler.clj
+++ b/src/leiningen/new/compojure/handler.clj
@@ -5,6 +5,7 @@
 
 (defroutes app-routes
   (GET "/" [] "Hello World")
+  (route/resources "/")
   (route/not-found "Not Found"))
 
 (def app


### PR DESCRIPTION
I think the base project template should include some standard static resources to make it less confusing as to how you create these things.

I've added JS and CSS directories in anticipation of a standard web project but I think even a web service template should have the static route available by default.
