### PR TITLE
Updating .gitignore to make it the same as the default lein.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,8 @@
 /classes
 /checkouts
 pom.xml
+pom.xml.asc
 *.jar
 *.class
-.lein-deps-sum
-.lein-failures
-.lein-plugins
-pom.xml.asc
+/.lein-*
+/.nrepl-port


### PR DESCRIPTION
.lein-repl-history was being checked in a project.

Looking at the .gitignore from default lein and from this template, seem that there is no need for a different .gitignore.
