### PR TITLE
Updating gitignore to make it almost the same as the default lein one.

### DIFF
--- a/src/leiningen/new/compojure/gitignore
+++ b/src/leiningen/new/compojure/gitignore
@@ -3,9 +3,8 @@
 /classes
 /checkouts
 pom.xml
+pom.xml.asc
 *.jar
 *.class
-.lein-deps-sum
-.lein-failures
-.lein-plugins
-.lein-env
+/.lein-*
+/.nrepl-port


### PR DESCRIPTION
`.lein-repl-history` and `.nrepl-port` were being checked in. Looking at the differences between this and the default lein, after this commit, there is an extra `/lib` entry in this one.
