### PR TITLE
  Fixing a bug with directories with dots in name

### DIFF
--- a/src/leiningen/new/compojure.clj
+++ b/src/leiningen/new/compojure.clj
@@ -1,5 +1,5 @@
 (ns leiningen.new.compojure
-  (:use [leiningen.new.templates :only [renderer sanitize year ->files]]
+  (:use [leiningen.new.templates :only [renderer sanitize year name-to-path ->files]]
         [leinjacker.utils :only [lein-generation]]))
 
 (def project-file
@@ -12,12 +12,13 @@
   [name]
   (let [data {:name name
               :sanitized (sanitize name)
+              :path (name-to-path name)
               :year (year)}
         render #((renderer "compojure") % data)]
     (->files data
              [".gitignore"  (render "gitignore")]
              ["project.clj" (render project-file)]
              ["README.md"   (render "README.md")]
-             ["src/{{sanitized}}/handler.clj"       (render "handler.clj")]
-             ["test/{{sanitized}}/test/handler.clj" (render "handler_test.clj")]
+             ["src/{{path}}/handler.clj"       (render "handler.clj")]
+             ["test/{{path}}/test/handler.clj" (render "handler_test.clj")]
              "resources/public")))


### PR DESCRIPTION
Hi,

I have fixed one bug in compojure-template. There are few steps for reproducing below:

> lein new compojure example.com
> cd example.com
> lein ring server

The current patch resolves project names that contain dot symbols and create right namespaces and folders for a lein project.

Could you review and merge it?

Minh
