### PR TITLE
add min-lein-version

### DIFF
--- a/src/leiningen/new/compojure/project_lein2.clj
+++ b/src/leiningen/new/compojure/project_lein2.clj
@@ -5,6 +5,7 @@
                  [compojure "1.1.8"]]
   :plugins [[lein-ring "0.8.11"]]
   :ring {:handler {{name}}.handler/app}
+  :min-lein-version "2.0.0"
   :profiles
   {:dev {:dependencies [[javax.servlet/servlet-api "2.5"]
                         [ring-mock "0.1.5"]]}})


### PR DESCRIPTION
I was working with someone at the Austin Clojure Meetup who was trying
to deploy a compojure template app to Heroku (actually, [Dokku](https://github.com/progrium/dokku), which
uses the Heroku buildpacks). He got tripped up by the template not
setting `min-lein-version`. Since this is a starting point for many new
Clojure apps, maybe we should set it by default?
