### PR TITLE
Fix up whitespace

### DIFF
--- a/resources/leiningen/new/compojure/handler_test.clj
+++ b/resources/leiningen/new/compojure/handler_test.clj
@@ -8,7 +8,7 @@
     (let [response (app (mock/request :get "/"))]
       (is (= (:status response) 200))
       (is (= (:body response) "Hello World"))))
-  
+
   (testing "not-found route"
     (let [response (app (mock/request :get "/invalid"))]
       (is (= (:status response) 404)))))


### PR DESCRIPTION
Was just starting a new project and found a some extra whitespace in the default handler test
