### PR TITLE
Fix order in test assertions

### DIFF
--- a/resources/leiningen/new/compojure/handler_test.clj
+++ b/resources/leiningen/new/compojure/handler_test.clj
@@ -6,9 +6,9 @@
 (deftest test-app
   (testing "main route"
     (let [response (app (mock/request :get "/"))]
-      (is (= (:status response) 200))
-      (is (= (:body response) "Hello World"))))
+      (is (= 200 (:status response)))
+      (is (= "Hello World" (:body response)))))
 
   (testing "not-found route"
     (let [response (app (mock/request :get "/invalid"))]
-      (is (= (:status response) 404)))))
+      (is (= 404 (:status response))))))


### PR DESCRIPTION
The convention for clojure.test is `(is (= expected actual))`, which is the reverse of what the template uses in handler_test.clj. This commit switches the arguments to `=` so that failures will be reported correctly.