### PR TITLE
Update generated readme

### DIFF
--- a/resources/leiningen/new/compojure/README.md
+++ b/resources/leiningen/new/compojure/README.md
@@ -14,6 +14,12 @@ To start a web server for the application, run:
 
     lein ring server
 
+To create and run a jar file for this application:
+
+    lein ring uberjar
+    java -jar target/{{name}}-0.1.0-standalone.jar
+
+
 ## License
 
 Copyright © {{year}} FIXME


### PR DESCRIPTION
Provide user with instructions for creating and running deployable jar file.
In days-gone-by, users had to set up a `-main` and manually call run-jetty.