### PR TITLE
Update template dependencies

### DIFF
--- a/resources/leiningen/new/compojure/project.clj
+++ b/resources/leiningen/new/compojure/project.clj
@@ -2,11 +2,11 @@
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :min-lein-version "2.0.0"
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [compojure "1.5.1"]
-                 [ring/ring-defaults "0.2.1"]]
-  :plugins [[lein-ring "0.9.7"]]
+  :dependencies [[org.clojure/clojure "1.9.0"]
+                 [compojure "1.6.1"]
+                 [ring/ring-defaults "0.3.2"]]
+  :plugins [[lein-ring "0.12.4"]]
   :ring {:handler {{namespace}}.handler/app}
   :profiles
-  {:dev {:dependencies [[javax.servlet/servlet-api "2.5"]
-                        [ring/ring-mock "0.3.0"]]}})
+  {:dev {:dependencies [[javax.servlet/servlet-api "3.1.0"]
+                        [ring/ring-mock "0.3.2"]]}})


### PR DESCRIPTION
Updated dependency versions in the template to the latest stable versions.

Tested new libraries work together by creating and running a new project using
the template.

* org.clojure/clojure 1.9.0
* compojure 1.6.1
* ring/defaults 0.3.2
* lein-ring 0.12.4
* ring/ring-mock 0.3.2

Thanks @weavejester for a great Leiningen template.