### PR TITLE
Update Clojure to 1.10.0

### DIFF
--- a/resources/leiningen/new/compojure/project.clj
+++ b/resources/leiningen/new/compojure/project.clj
@@ -2,7 +2,7 @@
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :min-lein-version "2.0.0"
-  :dependencies [[org.clojure/clojure "1.9.0"]
+  :dependencies [[org.clojure/clojure "1.10.0"]
                  [compojure "1.6.1"]
                  [ring/ring-defaults "0.3.2"]]
   :plugins [[lein-ring "0.12.4"]]


### PR DESCRIPTION
Update the Leiningen Compojure template to use Clojure version 1.10.0.