### PR TITLE
Fix the order of expected and actual in handler_test.clj template

### DIFF
--- a/resources/leiningen/new/compojure/handler_test.clj
+++ b/resources/leiningen/new/compojure/handler_test.clj
@@ -6,9 +6,9 @@
 (deftest test-app
   (testing "main route"
     (let [response (app (mock/request :get "/"))]
-      (is (= (:status response) 200))
-      (is (= (:body response) "Hello World"))))
+      (is (= 200 (:status response)))
+      (is (= "Hello World" (:body response)))))
 
   (testing "not-found route"
     (let [response (app (mock/request :get "/invalid"))]
-      (is (= (:status response) 404)))))
+      (is (= 404 (:status response))))))


### PR DESCRIPTION
Expected and actual values were mixed in the handler_test.clj template.

To demonstrate this, after creating a new compojure project I changed the expected value for the response body:
```
$ cat test/expected_actual/handler_test.clj
(ns expected-actual.handler-test
  (:require [clojure.test :refer :all]
            [ring.mock.request :as mock]
            [expected-actual.handler :refer :all]))

(deftest test-app
  (testing "main route"
    (let [response (app (mock/request :get "/"))]
      (is (= (:status response) 200))
      (is (= (:body response) "EXPECTED Hello World"))))

  (testing "not-found route"
    (let [response (app (mock/request :get "/invalid"))]
      (is (= (:status response) 404)))))
```

And running tests gives you this result, which is obviously wrong:
```
$ lein test

lein test expected-actual.handler-test

lein test :only expected-actual.handler-test/test-app

FAIL in (test-app) (handler_test.clj:10)
main route
expected: "Hello World"
  actual: "EXPECTED Hello World"
    diff: - "Hello World"
          + "EXPECTED Hello World"

Ran 1 tests containing 3 assertions.
1 failures, 0 errors.
Tests failed.
```